### PR TITLE
SPR1-2965: Basic package functionality

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,10 +7,6 @@ katsdp.setDependencies([
     'ska-sa/katsdpdockerbase/master',
     'ska-sa/katpoint/master',
     'ska-sa/katdal/master',
-    'ska-sa/katsdpsigproc/master',
-    'ska-sa/katsdpservices/master',
     'ska-sa/katsdptelstate/master'])
-katsdp.standardBuild(
-    docker_venv: true,
-    push_external: true)
-katsdp.mail('sdpdev+katsdpcal@ska.ac.za')
+katsdp.standardBuild()
+katsdp.mail('sdpdev+katsdpcalproc@ska.ac.za')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,4 +9,4 @@ katsdp.setDependencies([
     'ska-sa/katdal/master',
     'ska-sa/katsdptelstate/master'])
 katsdp.standardBuild()
-katsdp.mail('sdpdev+katsdpcalproc@ska.ac.za')
+katsdp.mail('sdpdev+katsdpcal@ska.ac.za')

--- a/README.md
+++ b/README.md
@@ -1,0 +1,6 @@
+# MeerKAT Science Data Processor Calibration Procedures (katsdpcalproc)
+
+This package contains calibration procedures (such as solvers, fitters,
+averagers and other low-level routines) for the MeerKAT calibration pipeline.
+This makes it easy to import these into other projects, without depending on
+the full machinery of the pipeline.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,37 @@
+[project]
+name = "katsdpcalproc"
+description = "Calibration procedures for the MeerKAT calibration pipeline"
+readme = "README.md"
+requires-python = ">=3.6"
+license = {file = "LICENSE"}
+authors = [
+        {name = "SARAO DSP team", email = "sdpdev+katsdpcalproc@ska.ac.za"}
+]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+    "Topic :: Scientific/Engineering :: Astronomy",
+]
+dependencies = [
+    "dask[array]>=1.1.0",
+    "katdal<1",
+    "katpoint<1",
+    "numba>=0.49.0",
+    "numpy>=1.15",
+    "scikits.fitting",
+    "scipy>=0.17",
+    "sortedcontainers",
+]
+dynamic = ["version"]
+
 [build-system]
-requires = ["setuptools", "wheel", "katversion"]
+requires = [
+        "setuptools>=45",
+        "setuptools_scm[toml]>=6.0",
+]
+
+[tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 requires-python = ">=3.6"
 license = {file = "LICENSE"}
 authors = [
-        {name = "SARAO DSP team", email = "sdpdev+katsdpcalproc@ska.ac.za"}
+        {name = "SARAO DSP team", email = "sdpdev+katsdpcal@ska.ac.za"}
 ]
 classifiers = [
     "Development Status :: 4 - Beta",

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,1 @@
+# Empty file, just to tell Jenkins to test with pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,30 +1,13 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
-aiokatcp
-astropy
-async_timeout
-attrs
-bokeh
-click==7.0              # for distributed
-cloudpickle==1.3.0      # for distributed
-dask[array,distributed]
-distributed==2.12.0
-docutils
-heapdict==1.0.1         # for distributed
-jsonschema
-matplotlib
+dask[array]
+future                   # for scikits.fitting
 numba
 numpy
-psutil==5.7.0           # for distributed
 scipy
+scikits.fitting==0.7.2
 sortedcontainers
-spead2
-tblib==1.6.0            # for distributed
-zict==2.0.0             # for distributed
 
 katdal @ git+https://github.com/ska-sa/katdal
 katpoint @ git+https://github.com/ska-sa/katpoint
-katsdpmodels[requests] @ git+https://github.com/ska-sa/katsdpmodels
-katsdpservices[argparse,aiomonitor] @ git+https://github.com/ska-sa/katsdpservices
-katsdpsigproc @ git+https://github.com/ska-sa/katsdpsigproc
 katsdptelstate @ git+https://github.com/ska-sa/katsdptelstate

--- a/setup.py
+++ b/setup.py
@@ -1,43 +1,21 @@
-#!/usr/bin/env python
-from setuptools import setup, find_packages
+################################################################################
+# Copyright (c) 2009-2023, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
 
-setup(
-    name="katsdpcal",
-    description="MeerKAT calibration pipeline",
-    maintainer="MeerKAT SDP Team",
-    maintainer_email="sdpdev+katsdpcal@ska.ac.za",
-    packages=find_packages(),
-    package_data={'': ['conf/*/*']},
-    include_package_data=True,
-    scripts=[
-        "scripts/run_cal.py",
-        "scripts/run_katsdpcal_sim.py",
-        "scripts/sim_ts.py",
-        "scripts/sim_data_stream.py",
-        "scripts/create_test_data.py"
-    ],
-    classifiers=[
-        "Development Status :: 3 - Alpha",
-        "Intended Audience :: Developers",
-        "License :: Other/Proprietary License",
-        "Operating System :: OS Independent",
-        "Programming Language :: Python",
-        "Topic :: Software Development :: Libraries :: Python Modules",
-        "Topic :: Scientific/Engineering :: Astronomy",
-    ],
-    platforms=["OS Independent"],
-    keywords="kat kat7 meerkat ska",
-    zip_safe=False,
-    python_requires=">=3.5",
-    install_requires=[
-        "numpy>=1.15", "scipy>=0.17", "numba>=0.49.0",
-        "dask[array,distributed]>=1.1.0", "distributed>=2.2.0", "bokeh",
-        "attrs", "sortedcontainers",
-        "aiokatcp", "astropy", "async_timeout",
-        "katpoint", "katdal", "katsdpmodels[requests]", "katsdptelstate",
-        "katsdpservices[argparse,aiomonitor]", "katsdpsigproc", "spead2>=3.0.0",
-        "docutils", "matplotlib>=2", "jsonschema"
-    ],
-    tests_require=["nose", "asynctest"],
-    use_katversion=True
-)
+from setuptools import setup
+
+# The metadata is all in pyproject.toml.
+# This step is just to support editable installs.
+setup()

--- a/src/katsdpcalproc/calprocs_dask.py
+++ b/src/katsdpcalproc/calprocs_dask.py
@@ -25,7 +25,7 @@ def stefcal(rawvis, num_ants, corrprod_lookup, weights=None, ref_ant=0,
             init_gain=None, *args, **kwargs):
     """Solve for antenna gains using StEFCal.
 
-    Refer to :func:`katsdpcal.calprocs.stefcal` for details. This version
+    Refer to :func:`katsdpcalproc.calprocs.stefcal` for details. This version
     expects a dask array for `rawvis`, and optionally for `weights` and
     `init_gain` as well.
     """

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,5 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
-asynctest
 coverage
-nose
+pytest
+pytest-cov

--- a/tests/test_calprocs.py
+++ b/tests/test_calprocs.py
@@ -5,9 +5,9 @@ import time
 
 import numpy as np
 
-from katsdpcal import calprocs
+from katsdpcalproc import calprocs
 
-from katsdpcal.solutions import CalSolution, CalSolutionStore
+from katsdpcalproc.solutions import CalSolution, CalSolutionStore
 
 
 def unit(value):
@@ -29,7 +29,7 @@ class TestCalprocs(unittest.TestCase):
 
 
 class TestStefcal(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.stefcal`."""
+    """Tests for :func:`katsdpcalproc.calprocs.stefcal`."""
     def setUp(self):
         self.random_state = np.random.RandomState(seed=1)
 
@@ -246,7 +246,7 @@ class TestStefcal(unittest.TestCase):
 
 
 class TestWavgFullF(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.wavg_full_f`"""
+    """Tests for :func:`katsdpcalproc.calprocs.wavg_full_f`"""
     def setUp(self):
         shape = (5, 10, 3, 10)
         self.data = np.ones(shape, np.complex64)
@@ -374,7 +374,7 @@ class TestWavgFlagsF(unittest.TestCase):
 
 
 class TestNormaliseComplex(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.normalise_complex`"""
+    """Tests for :func:`katsdpcalproc.calprocs.normalise_complex`"""
     def setUp(self):
         shape = (6, 7, 2)
         self.data = np.ones(shape, np.complex64) + 1.j
@@ -432,7 +432,7 @@ class TestNormaliseComplex(unittest.TestCase):
 
 
 class TestKAnt(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.K_ant'"""
+    """Tests for :func:`katsdpcalproc.calprocs.K_ant'"""
     def test(self):
         ntimes = 3
         nchans = 2
@@ -457,7 +457,7 @@ class TestKAnt(unittest.TestCase):
 
 
 class TestMeasureFlux(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.measure_flux'"""
+    """Tests for :func:`katsdpcalproc.calprocs.measure_flux'"""
     def setUp(self):
         ntimes = 4
         self.gains1 = np.ones((ntimes, 5), dtype=np.complex64)
@@ -542,7 +542,7 @@ class TestMeasureFlux(unittest.TestCase):
 
 
 class TestAddModelVis(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.add_model_vis`"""
+    """Tests for :func:`katsdpcalproc.calprocs.add_model_vis`"""
     def test(self):
         shape = (3, 5, 4)
         kant = np.ones(shape, np.complex64)
@@ -563,7 +563,7 @@ class TestAddModelVis(unittest.TestCase):
 
 
 class TestCalcSnr(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.calc_snr`"""
+    """Tests for :func:`katsdpcalproc.calprocs.calc_snr`"""
     def setUp(self):
         shape = (7, 3, 2)
         self.data = np.ones(shape, np.float32)
@@ -589,7 +589,7 @@ class TestCalcSnr(unittest.TestCase):
 
 
 class TestPoorAntennaFlags(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.poor_antenna_flags`"""
+    """Tests for :func:`katsdpcalproc.calprocs.poor_antenna_flags`"""
     def test(self):
         nants = 5
         shape = (2, 10, 2, nants*(nants-1)//2)
@@ -621,7 +621,7 @@ class TestPoorAntennaFlags(unittest.TestCase):
 
 
 class TestSnrAntenna(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.snr_antenna`"""
+    """Tests for :func:`katsdpcalproc.calprocs.snr_antenna`"""
     def setUp(self):
         nants = 5
         self.shape = (2, 10, 2, nants*(nants-1)//2)
@@ -678,7 +678,7 @@ class TestSnrAntenna(unittest.TestCase):
 
 
 class TestFluxDensityModel(unittest.TestCase):
-    """Tests for :class:`katsdpcal.calprocs.FluxDensityModel`"""
+    """Tests for :class:`katsdpcalproc.calprocs.FluxDensityModel`"""
 
     def _test_inputs(self, expected_flux, *args):
         """Tests flux density produced with given parameters or description string"""
@@ -789,7 +789,7 @@ class TestGetReordering(unittest.TestCase):
 
 
 class TestInterpolateSoln(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs.interpolate_soln`"""
+    """Tests for :func:`katsdpcalproc.calprocs.interpolate_soln`"""
     def test(self):
         shape = (4, 2, 5)
         xi = [1, 2, 4, 5]

--- a/tests/test_calprocs_dask.py
+++ b/tests/test_calprocs_dask.py
@@ -1,12 +1,13 @@
-"""Tests for :mod:`katsdpcal.calprocs_dask`."""
+"""Tests for :mod:`katsdpcalproc.calprocs_dask`."""
 
 import unittest
 
 import numpy as np
 import dask.array as da
 
-from katsdpcal import calprocs, calprocs_dask
-from . import test_calprocs
+from katsdpcalproc import calprocs, calprocs_dask
+
+import test_calprocs
 
 
 def as_dask(arr):
@@ -18,7 +19,7 @@ def unit(value):
 
 
 class TestStefcal(test_calprocs.TestStefcal):
-    """Tests for :func:`katsdpcal.calprocs_dask.stefcal`."""
+    """Tests for :func:`katsdpcalproc.calprocs_dask.stefcal`."""
     def _call_stefcal(self, rawvis, num_ants, corrprod_lookup, weights=None,
                       ref_ant=0, init_gain=None, *args, **kwargs):
         rawvis = da.asarray(rawvis)
@@ -72,7 +73,7 @@ class TestAlignChunks(unittest.TestCase):
 
 
 class TestWavg(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs_dask.wavg`"""
+    """Tests for :func:`katsdpcalproc.calprocs_dask.wavg`"""
     def setUp(self):
         shape = (10, 5, 3, 10)
         self.data = np.ones(shape, np.complex64)
@@ -139,7 +140,7 @@ class TestWavg(unittest.TestCase):
 
 
 class TestWavgFullT(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs_dask.wavg_full_t`"""
+    """Tests for :func:`katsdpcalproc.calprocs_dask.wavg_full_t`"""
     def setUp(self):
         shape = (10, 5, 3, 10)
         self.data = np.ones(shape, np.complex64)
@@ -201,10 +202,10 @@ class TestWavgFullT(unittest.TestCase):
 
 
 class TestWavgFullF(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs_dask.wavg_full_f`
+    """Tests for :func:`katsdpcalproc.calprocs_dask.wavg_full_f`
 
     The tests just compare results against
-    :func:`katsdpcal.calprocs.wavg_full_f` (i.e., the non-dask version),
+    :func:`katsdpcalproc.calprocs.wavg_full_f` (i.e., the non-dask version),
     which is assumed to have its own tests.
     """
     def _test(self, shape, chunks, chanav):
@@ -246,7 +247,7 @@ class TestWavgFullF(unittest.TestCase):
 
 
 class TestWavgAnt(unittest.TestCase):
-    """Tests for :func:`katsdpcal.calprocs_dask.wavg_ant`"""
+    """Tests for :func:`katsdpcalproc.calprocs_dask.wavg_ant`"""
     def setUp(self):
         shape = (10, 5, 3, 10)
         self.data = np.ones(shape, np.complex64)

--- a/tests/test_solutions.py
+++ b/tests/test_solutions.py
@@ -1,14 +1,16 @@
-"""Tests for :mod:`katsdpcal.solutions`"""
+"""Tests for :mod:`katsdpcalproc.solutions`"""
 
 import unittest
 
 import numpy as np
 
-from ..solutions import CalSolution, CalSolutionStore, CalSolutionStoreLatest
+from katsdpcalproc.solutions import (
+    CalSolution, CalSolutionStore, CalSolutionStoreLatest
+)
 
 
 class TestCalSolutionStoreLatest(unittest.TestCase):
-    test_cls = CalSolutionStoreLatest
+    make_store = CalSolutionStoreLatest
 
     def setUp(self):
         self.sol1 = CalSolution('G', np.arange(10), 1234.0, 'sol1')
@@ -16,7 +18,7 @@ class TestCalSolutionStoreLatest(unittest.TestCase):
         self.sol3 = CalSolution('G', np.arange(30, 40), 3456.0, 'sol3')
         self.solK = CalSolution('K', np.arange(30, 40), 3456.0, 'solK')
         self.sol4 = CalSolution('G', np.arange(10), 4567.0, 'sol1')
-        self.store = self.test_cls('G')
+        self.store = self.make_store('G')
 
     def test_latest_empty(self):
         self.assertIsNone(self.store.latest)
@@ -39,7 +41,7 @@ class TestCalSolutionStoreLatest(unittest.TestCase):
 
 
 class TestCalSolutionStore(TestCalSolutionStoreLatest):
-    test_cls = CalSolutionStore
+    make_store = CalSolutionStore
 
     def test_get_range(self):
         self.store.add(self.sol2)


### PR DESCRIPTION
The start of a shiny new (old?) package 😂 

Modernise the package metadata:

- Standardise as much as possible on `pyproject.toml`. Minimise `setup.py` and avoid `setup.cfg`.
- Replace `katversion` with `setuptools_scm` (I miss branch names in the version string though...).
- Use `README.md` instead of `README.rst`.
- Strip down dependency list.
- Fix tests to work with `pytest`.
- Enable continuous integration with Jenkins (check those green ticks ✓😁).