### PR TITLE
SPR1-3025: align pointing inputs with cal pipeline outputs

### DIFF
--- a/src/katsdpcalproc/pointing.py
+++ b/src/katsdpcalproc/pointing.py
@@ -93,7 +93,7 @@ def get_offset_gains(bp_gains, offsets, ants, track_duration,
                 stats_N = ' '.join("%4d" % (n,) for n in abs_gain_N)
                 bp_mean = np.nanmean(np.abs(bp_gain))
                 logger.debug("%s %s %4.2f mean | %s",
-                             tuple(offset), inp, np.abs(bp_gain), stats_mean)
+                             tuple(offset), inp, bp_mean, stats_mean)
                 logger.debug("%s %s %4.2f std  | %s",
                              tuple(offset), inp, bp_mean, stats_std)
                 logger.debug("%s %s      N    | %s",

--- a/src/katsdpcalproc/pointing.py
+++ b/src/katsdpcalproc/pointing.py
@@ -59,7 +59,7 @@ def get_offset_gains(bp_gains, offsets, ants, track_duration,
                                    * (bandwidth / bp_gains.shape[1]))
     chunk_freqs = channel_freqs.reshape(num_chunks, -1).mean(axis=1)
     data_points = {}
-    for offset, offset_bp_gain in zip(offsets,bp_gains):
+    for offset, offset_bp_gain in zip(offsets, bp_gains):
         for a, ant in enumerate(ants):
             pol_gain = np.zeros(num_chunks)
             pol_weight = np.zeros(num_chunks)
@@ -86,8 +86,6 @@ def get_offset_gains(bp_gains, offsets, ants, track_duration,
                 # Generate standard precision weights based on empirical stdev
                 abs_gain_weight = abs_gain_N / abs_gain_var
                 # Prepare some debugging output
-                stats_mean = ' '.join("%4.2f" % (m,) for m in
-                                      abs_gain_mean.filled(np.nan))
                 stats_std = ' '.join("%4.2f" % (s,) for s in
                                      abs_gain_std.filled(np.nan))
                 stats_N = ' '.join("%4d" % (n,) for n in abs_gain_N)

--- a/src/katsdpcalproc/pointing.py
+++ b/src/katsdpcalproc/pointing.py
@@ -86,10 +86,14 @@ def get_offset_gains(bp_gains, offsets, ants, track_duration,
                 # Generate standard precision weights based on empirical stdev
                 abs_gain_weight = abs_gain_N / abs_gain_var
                 # Prepare some debugging output
+                stats_mean = ' '.join("%4.2f" % (m,) for m in
+                                      abs_gain_mean.filled(np.nan))
                 stats_std = ' '.join("%4.2f" % (s,) for s in
                                      abs_gain_std.filled(np.nan))
                 stats_N = ' '.join("%4d" % (n,) for n in abs_gain_N)
                 bp_mean = np.nanmean(np.abs(bp_gain))
+                logger.debug("%s %s %4.2f mean | %s",
+                             tuple(offset), inp, np.abs(bp_gain), stats_mean)
                 logger.debug("%s %s %4.2f std  | %s",
                              tuple(offset), inp, bp_mean, stats_std)
                 logger.debug("%s %s      N    | %s",

--- a/tests/test_pointing.py
+++ b/tests/test_pointing.py
@@ -58,9 +58,6 @@ ANT_DESCRIPTIONS = ["""m000,
 ants = [katpoint.Antenna(ant) for ant in ANT_DESCRIPTIONS]
 az_el_adjust = np.zeros((len(ants), 2))
 
-# Creating gains, numpy array shape (no.offsets, no.polarisations, no.antennas)
-just_gains = np.ones((len(offsets), len(POLS), len(ants)), dtype=np.complex64)
-
 
 def generate_bp_gains(offsets, ants, channel_freqs, pols, beam_center=(0.5, 0.5)):
     """ Creating bp_gains, numpy array of shape:
@@ -97,7 +94,6 @@ def generate_bp_gains(offsets, ants, channel_freqs, pols, beam_center=(0.5, 0.5)
 bp_gains = generate_bp_gains(offsets, ants, channel_freqs, POLS)
 data_points = pointing.get_offset_gains(
     bp_gains,
-    just_gains,
     offsets,
     ants,
     TRACK_DURATION,
@@ -128,7 +124,6 @@ def test_get_offset_gains_shape():
     with pytest.raises(ValueError):
         pointing.get_offset_gains(
             bp_gains[0],
-            just_gains[0],
             offsets,
             ants,
             TRACK_DURATION,


### PR DESCRIPTION
Edited the pointing script , specifically get_offset_gains function to take in only bandpass gains instead of both gains and bandpass gains. Also edited the test script to be compatible.