### PR TITLE
SPR1-1964: Reference Antenna Selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "numba>=0.49.0",
     "numpy>=1.15",
     "scikits.fitting",
-    "scipy>=0.17",
+    "scipy>=1.5.0",
     "sortedcontainers",
 ]
 dynamic = ["version"]

--- a/src/katsdpcalproc/calprocs.py
+++ b/src/katsdpcalproc/calprocs.py
@@ -357,25 +357,29 @@ def select_med_deviation_pnr_ants(med_pnr_ants):
 def best_refant(data, corrprod_lookup, chans):
     """Identify antenna that is most suited to be the reference antenna.
 
-    This function determines the best reference antenna through the following process:
+    This function determines the best reference antenna through the following
+    process:
 
-    - Perform a Fourier Transform on the visibilities along the frequency axis. Since the
-      visibilities from the correlator have roughly linear phase slopes, the resultant
-      FFT of the visibilities are expected to be highly peaked.
+    - Perform a Fourier Transform on the visibilities along the frequency
+      axis. Since the visibilities obtained from a calibrator have roughly
+      linear phase slopes across the band, the resultant FFT of the
+      visibilities are expected to be highly peaked.
 
-    - Calculate the peak-to-noise ratio (PNR) for all baselines per antenna to measure the
-      strength of the peaked visibilities. Highly peaked visibilities indicates good signal
-      coherence and quality for phase calibration.
+    - Calculate the peak-to-noise ratio (PNR) per baseline and per dump to
+      measure the strength of the peaked visibilities. Highly peaked
+      visibilities indicates good signal coherence and quality for phase
+      calibration.
 
-    - Calculate the median PNR, this serves as a robust figure of merit for identifying antenna
-      that have good signal coherence.
+    - Calculate the median PNR per antenna. This serves as a robust figure of
+      merit for identifying antennas that have good signal coherence.
 
-    - Select antennas with high median PNR values by applying the select_med_deviation_pnr_ants()
-      function, i.e. removes roughly the bottom 20% of antenna from being selected as a candidate
-      reference antenna for calibration.
+    - Select antennas with high median PNR values by applying the
+      :func:`select_med_deviation_pnr_ants` function. This removes roughly the
+      bottom 20% of antennas from being selected as a candidate reference
+      antenna for calibration.
 
-    - Sort the remaining antenna indices in descending order to promote the outer antennas
-      above the core antennas.
+    - Sort the remaining antenna indices in descending order to promote the
+      outer antennas (large indices) above the core antennas (small indices).
 
     Parameters
     ----------
@@ -389,9 +393,10 @@ def best_refant(data, corrprod_lookup, chans):
     Returns
     -------
     refant_best_to_worse : :class:`np.ndarray`
-       Array of antenna indices sorted according to the suitability of the corresponding antenna
-       to be the reference antenna. The first antenna index in the list is considered to be the
-       best candidate reference antenna.
+       Array of antenna indices sorted according to the suitability of the
+       corresponding antenna to be the reference antenna. The first antenna
+       index in the list is considered to be the best candidate reference
+       antenna.
     """
     # Detect position of fft peak
     ft_vis = scipy.fftpack.fft(data, axis=0)

--- a/src/katsdpcalproc/calprocs.py
+++ b/src/katsdpcalproc/calprocs.py
@@ -329,11 +329,53 @@ def ants_from_bllist(bllist):
     return len(set([item for sublist in bllist for item in sublist]))
 
 
+def select_med_deviation_pnr_ants(med_pnr_ants):
+    """Median Absolute Deviation of Reference Antenna PNR values.
+    Select antenna peak to noise (PNR) values that are above the normalised median absolute
+    deviation (NMAD) Threshold for best reference antenna selection.
+    This ensures that a subset of antennas with reasonable peak to noise are selected.
+
+    Parameters
+    ----------
+    med_pnr_ants : :class:`np.ndarray`
+       Array of antenna Median Peak to Noise values
+
+    Returns
+    -------
+    select_med_deviation_pnr_ants : class:`np.ndarray`
+       Array of corresponding ant indices with PNR values that are above the normalised
+       median absolute deviation threshold"""
+
+    ant_indices = np.arange(len(med_pnr_ants))
+    median = np.nanmedian(med_pnr_ants)
+    mad = scipy.stats.median_abs_deviation(med_pnr_ants, nan_policy='omit')
+    nmad_threshold = (median - 1.4826 * mad)
+
+    return ant_indices[med_pnr_ants >= nmad_threshold]
+
+
 def best_refant(data, corrprod_lookup, chans):
     """Identify antenna that is most suited to be the reference antenna.
 
-    Determine antenna whose FFT has the maximum peak to noise ratio (PNR) by
-    taking the median PNR of the FFT over all baselines to each antenna.
+    This function determines the best reference antenna through the following process:
+
+    - Perform a Fourier Transform on the visibilities along the frequency axis. Since the
+      visibilities from the correlator have roughly linear phase slopes, the resultant
+      FFT of the visibilities are expected to be highly peaked.
+
+    - Calculate the peak-to-noise ratio (PNR) for all baselines per antenna to measure the
+      strength of the peaked visibilities. Highly peaked visibilities indicates good signal
+      coherence and quality for phase calibration.
+
+    - Calculate the median PNR, this serves as a robust figure of merit for identifying antenna
+      that have good signal coherence.
+
+    - Select antennas with high median PNR values by applying the select_med_deviation_pnr_ants()
+      function, i.e. removes roughly the bottom 20% of antenna from being selected as a candidate
+      reference antenna for calibration.
+
+    - Sort the remaining antenna indices in descending order to promote the outer antennas
+      above the core antennas.
 
     Parameters
     ----------
@@ -346,8 +388,10 @@ def best_refant(data, corrprod_lookup, chans):
 
     Returns
     -------
-    best_refant : :class:`np.ndarray`
-        Array of indices of antennas in decreasing order of median of PNR over all baselines
+    refant_best_to_worse : :class:`np.ndarray`
+       Array of antenna indices sorted according to the suitability of the corresponding antenna
+       to be the reference antenna. The first antenna index in the list is considered to be the
+       best candidate reference antenna.
     """
     # Detect position of fft peak
     ft_vis = scipy.fftpack.fft(data, axis=0)
@@ -373,8 +417,11 @@ def best_refant(data, corrprod_lookup, chans):
         # NB: it's important that mask is an np.ndarray here and not a list,
         # due to https://github.com/numpy/numpy/pull/13715
         pnr = (peak[..., mask] - mean[..., mask]) / std[..., mask]
-        med_pnr_ants[a] = np.median(pnr)
-    return np.argsort(med_pnr_ants)[::-1]
+        med_pnr_ants[a] = np.nanmedian(pnr)
+    high_ants = select_med_deviation_pnr_ants(med_pnr_ants)
+    refant_best_to_worse = np.sort(high_ants)[::-1]
+
+    return refant_best_to_worse
 
 
 def g_fit(data, weights, corrprod_lookup,  g0=None, refant=0, **kwargs):

--- a/tests/test_calprocs.py
+++ b/tests/test_calprocs.py
@@ -812,3 +812,62 @@ class TestInterpolateSoln(unittest.TestCase):
         expected[:, 1, 2] = np.array([6, 8]) * np.exp(1.j * np.pi / 180 * np.array([30, 40]))
 
         np.testing.assert_almost_equal(out, expected, 6)
+
+
+class TestSelectMedDeviation(unittest.TestCase):
+    """Tests for :func:`katsdpcal.calprocs.select_med_deviation
+    This tests that the Median Absolute Deviation (MAD) threshold is correctly calulated
+    for even/odd PNR value arrays or where nans are present"""
+    def test_nan_pnr_values(self):
+        """Test that nan values are omitted in median absolute deviation calculation"""
+        med_pnr = np.array([1, np.nan, 3, 4, 5])
+        # median: 3.5, median_deviation: 1, mad_threshold: 2.5
+        expected_mad_pnr = np.array([2, 3, 4])  # Corresponds to antenna med pnr values >= 2.5
+        result_mad_pnr = calprocs.select_med_deviation_pnr_ants(med_pnr)
+        np.testing.assert_equal(expected_mad_pnr, result_mad_pnr)
+
+    def test_evenArray_pnr_values(self):
+        """Test that for an even array the MAD selection is correct"""
+        med_pnr = np.array([1, 2, 3, 4])
+        # median: 2.5, median_deviation: 1, mad_threshold: 1.5
+        expected_mad_pnr = np.array([1, 2, 3])  # Corresponds to antenna med pnr values >= 1.5
+        result_mad_pnr = calprocs.select_med_deviation_pnr_ants(med_pnr)
+        np.testing.assert_equal(expected_mad_pnr, result_mad_pnr)
+
+    def test_oddArray_pnr_values(self):
+        """Test that for an odd array the MAD selection is correct"""
+        med_pnr = np.array([1, 2, 3, 4, 5])
+        # median: 3 , median_deviation: 1, mad_threshold: 2
+        expected_mad_pnr = np.array([1, 2, 3, 4])  # Corresponds to antenna med pnr values >= 2
+        result_mad_pnr = calprocs.select_med_deviation_pnr_ants(med_pnr)
+        np.testing.assert_equal(expected_mad_pnr, result_mad_pnr)
+
+
+class TestBestRefAnt(unittest.TestCase):
+    """Tests for :func:`katsdpcal.calprocs.best_refant`"""
+    def setUp(self):
+        self.bls = np.array([[0, 0, 1, 0, 1, 2, 0, 1, 2, 3], [1, 2, 2, 3, 3, 3, 4, 4, 4, 4]]).T
+        self.freqs = np.linspace(950e6, 1720e6, 10)
+        self.rs = np.random.RandomState(seed=1)
+        k = self.rs.uniform(1e-9, 5e-9, (2, 5))
+        delay_bls = k[:, self.bls[:, 0]] - k[:, self.bls[:, 1]]
+        self.vis = np.exp(2.j * np.pi * self.freqs[:, np.newaxis][:, np.newaxis]*delay_bls[:, :])
+        noise = 0.1 * (self.rs.random_sample((10, 2, 10)) - 0.1)
+        self.vis *= np.exp(1.j * noise)
+
+    def test_nan_antenna(self):
+        """Test that a nan antenna is not selected by best_refant"""
+
+        nan_antenna = [np.any(1 == x) for x in self.bls]
+        self.vis[:, :, nan_antenna] = np.nan
+        candidate_ants = calprocs.best_refant(self.vis, self.bls, self.freqs)
+        assert 1 not in candidate_ants
+
+    def test_noisy_antenna(self):
+        """Test that a noisy antenna is not selected by best_refant"""
+
+        noisy_mask = (self.bls[:, 0] == 2) ^ (self.bls[:, 1] == 2)
+        extra_noise = 10 * (self.rs.random_sample((10, 4)) - 0.5)  # Add higher noise level
+        self.vis[:, 0, noisy_mask] *= np.exp(1.j * extra_noise)
+        candidate_ants = calprocs.best_refant(self.vis, self.bls, self.freqs)
+        assert 2 not in candidate_ants


### PR DESCRIPTION
This is a PR for reference antenna selection as per the initial investigation done in [SPR1-1964](https://skaafrica.atlassian.net/browse/SPR1-1964). It is a transplant of ska-sa/katsdpcal#69 in anticipation of removing calproc from katsdpcal.

A `select_med_deviation_pnr_ants` function has been added to calculate the median deviation of antenna peak-to-noise (PNR) values, this function returns an array of antenna indices that have a relatively good PNR. We have considered antenna PNRs that are one normalized deviation below the median as being relatively unsuitable for selection as the reference antenna. The `best_refant`, which is the function that calculates the PNR across antennas, has been modified to call the `select_med_deviation_pnr_ants` and thereafter return the corresponding best antenna solution for the reference antenna selection.
The `test_calprocs.py` contains the corresponding unit tests for the new solution in `select_med_deviation_pnr_ants` and `best_refant`.

After this PR the calproc code and tests only differ in imports and docstrings.

[SPR1-1964]: https://skaafrica.atlassian.net/browse/SPR1-1964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ