### PR TITLE
SPR1-3119: Replace scikits.fitting with Astropy modeling fitters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,12 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Astronomy",
 ]
 dependencies = [
+    "astropy",
     "dask[array]>=1.1.0",
     "katdal<1",
     "katpoint<1",
     "numba>=0.49.0",
     "numpy>=1.15",
-    "scikits.fitting",
     "scipy>=1.5.0",
     "sortedcontainers",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 -c https://raw.githubusercontent.com/ska-sa/katsdpdockerbase/master/docker-base-build/base-requirements.txt
 
+astropy
 dask[array]
-future                   # for scikits.fitting
 numba
 numpy
 scipy
-scikits.fitting==0.7.2
 sortedcontainers
 
 katdal @ git+https://github.com/ska-sa/katdal

--- a/src/katsdpcalproc/pointing.py
+++ b/src/katsdpcalproc/pointing.py
@@ -152,6 +152,7 @@ class BeamPatternFit:
         # Fix theta = 0 to ensure that elliptical beam contours line up with axes
         model.theta.fixed = True
         self._set_model(model)
+        # TODO Replace with fitting.LMLSQFitter once we depend on Astropy >= 5.1
         self._fit = fitting.LevMarLSQFitter(calc_uncertainties=True)
         self.expected_width = width
         self.is_valid = False
@@ -185,7 +186,7 @@ class BeamPatternFit:
         self._set_model(new_model)
         param_cov = self._fit.fit_info['param_cov']
         # The parameter cov matrix is absent if singular: be very uncertain then
-        # XXX Only an issue with LevMarLSQFitter - remove check for LMLSQFitter
+        # TODO Only an issue with LevMarLSQFitter - remove check for LMLSQFitter
         if param_cov is None:
             param_std = np.full(5, np.inf)
         else:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,26 @@
+################################################################################
+# Copyright (c) 2024, National Research Foundation (SARAO)
+#
+# Licensed under the BSD 3-Clause License (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy
+# of the License at
+#
+#   https://opensource.org/licenses/BSD-3-Clause
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+################################################################################
+
+"""Global fixtures."""
+
+import pytest
+from numpy.random import RandomState
+
+
+@pytest.fixture(name="random")
+def fixture_random():
+    """Provide repeatable 'random' generator in place of np.random."""
+    return RandomState((4, 8, 15, 16, 23, 42))

--- a/tests/test_pointing.py
+++ b/tests/test_pointing.py
@@ -233,8 +233,8 @@ def test_gaussian_beam_fit_accuracy():
     .. [Condon1997] J. J. Condon, "Errors in Elliptical Gaussian Fits,"
        PASP, vol. 109, pp. 166-172, Feb 1997.
     """
-    # The number of Gaussians to fit
-    T = 1000
+    # The number of Gaussians to fit (reduced from 1000 to save time)
+    T = 100
     # The size of a pixel in data coordinates (i.e. length of each pixel side)
     h = 0.1
     # The rms noise amplitude on each pixel
@@ -284,8 +284,8 @@ def test_gaussian_beam_fit_accuracy():
         true_beam_std = _beam_params_std(true_beam, error_scale[t])
         # XXX Estimate the uncertainty of the uncertainty (beware, thumbsuck!)
         beam_std_std = beam_std * error_scale[t]
-        beam_std_std[0] *= 0.7
-        beam_std_std[1:] *= 0.8 * np.sqrt(FWHM_SCALE)
+        beam_std_std[0] *= 1.1
+        beam_std_std[1:] *= np.sqrt(FWHM_SCALE)
         # Compare estimated / fitted to true uncertainties and standardise errors
         p_errors[5:, t] = (beam_std_estm - true_beam_std) / beam_std_std
     # Remove failed fits

--- a/tests/test_pointing.py
+++ b/tests/test_pointing.py
@@ -5,7 +5,6 @@ import katpoint
 import pytest
 from katsdpcalproc import pointing
 import cmath
-import random
 import scipy.stats
 
 # Creating metadata fpr tests
@@ -88,7 +87,7 @@ def generate_bp_gains(offsets, ants, channel_freqs, pols, beam_center=(0.5, 0.5)
                 for k in ex_width:
                     new_beam = pointing.BeamPatternFit(beam_center, k, 1.0)
                     g = new_beam(x=offsets[i].T)
-                    cmplx = random.uniform(-1.5, 1.5)
+                    cmplx = np.random.uniform(-1.5, 1.5)
                     g = cmath.rect(g, cmplx)
                     gains.append(np.array(g))
                 gains = np.array(gains).T
@@ -199,7 +198,7 @@ def _beam_params_std(beam, error_scale):
     return np.r_[beam.height, beam.width / FWHM_SCALE, beam.width] * error_scale
 
 
-def test_gaussian_beam_fit_accuracy():
+def test_gaussian_beam_fit_accuracy(random):
     r"""Reproduce Jim Condon's 2-D Gaussian fitting simulation.
 
     This repeats a computer simulation described in [Condon1997]_, which
@@ -244,7 +243,7 @@ def test_gaussian_beam_fit_accuracy():
     # Generate square "image" on which Gaussians will be sampled
     xy_k = np.reshape(np.meshgrid(samples_1d, samples_1d), (2, -1))
     # Generate beam centers within a few pixels of origin
-    x0, y0 = 10 * h * (np.random.rand(2, T) - 0.5)
+    x0, y0 = 10 * h * (random.rand(2, T) - 0.5)
     # Beam amplitude
     A = 20 * mu
     # Beam diameters along x and y
@@ -252,8 +251,8 @@ def test_gaussian_beam_fit_accuracy():
     theta_M = 8 * h
     theta_m = 20 * h / 3
     # Vary the beam diameter by a few percent to make it more realistic
-    fwhm_x = theta_M * (1 + 0.04 * (np.random.rand(T) - 0.5))
-    fwhm_y = theta_m * (1 + 0.04 * (np.random.rand(T) - 0.5))
+    fwhm_x = theta_M * (1 + 0.04 * (random.rand(T) - 0.5))
+    fwhm_y = theta_m * (1 + 0.04 * (random.rand(T) - 0.5))
     # Beam position angle is set to phi = 0 instead due to fitter limitation
     # Effective number of independent samples in fitted Gaussian
     N = (np.pi / FWHM_SCALE ** 2) * fwhm_x * fwhm_y / h ** 2
@@ -268,7 +267,7 @@ def test_gaussian_beam_fit_accuracy():
         # XXX This assumes that BeamPatternFit fits a Gaussian beam
         true_beam = pointing.BeamPatternFit((x0[t], y0[t]), (fwhm_x[t], fwhm_y[t]), A)
         # Generate noisy beam amplitude samples on pixel grid
-        a_k = true_beam(xy_k) + mu * np.random.randn(xy_k.shape[1])
+        a_k = true_beam(xy_k) + mu * random.randn(xy_k.shape[1])
         # Assume we have a good idea of beamwidth (needed to check beam validity)
         beam = pointing.BeamPatternFit((0.0, 0.0), (theta_M, theta_m), max(a_k))
         beam.fit(xy_k, a_k, mu)

--- a/tests/test_pointing.py
+++ b/tests/test_pointing.py
@@ -20,20 +20,22 @@ CENTER_FREQ = 1284000000.0
 BANDWIDTH = 856000000.0
 N_CHANNELS = 1000
 
+
+def _pointing_offsets(max_extent, num_pointings):
+    """Build up sequence of pointing offsets running linearly in x and y directions."""
+    scan = np.linspace(-max_extent, max_extent, num_pointings // 2)
+    offsets_along_x = np.c_[scan, np.zeros_like(scan)]
+    offsets_along_y = np.c_[np.zeros_like(scan), scan]
+    return np.r_[offsets_along_y, offsets_along_x]
+
+
 # Calculating channel and chunk freqencies
 channel_freqs = CENTER_FREQ + (np.arange(N_CHANNELS) - N_CHANNELS / 2) * (BANDWIDTH / N_CHANNELS)
 chunk_freqs = channel_freqs.reshape(NUM_CHUNKS, -1).mean(axis=1)
 target = katpoint.Target(
     body="J1939-6342, radec bfcal single_accumulation, 19:39:25.03, -63:42:45.6")
-
 # Maximum distance of offset from target, in degrees
-max_extent = 1.0
-num_pointings = 8
-# Build up sequence of pointing offsets running linearly in x and y directions
-scan = np.linspace(-max_extent, max_extent, num_pointings // 2)
-offsets_along_x = np.c_[scan, np.zeros_like(scan)]
-offsets_along_y = np.c_[np.zeros_like(scan), scan]
-offsets = np.r_[offsets_along_y, offsets_along_x]
+offsets = _pointing_offsets(max_extent=1.0, num_pointings=8)
 
 # Creating list of antenna objects
 ANT_DESCRIPTIONS = ["""m000,

--- a/tests/test_pointing.py
+++ b/tests/test_pointing.py
@@ -6,6 +6,7 @@ import pytest
 from katsdpcalproc import pointing
 import cmath
 import random
+import scipy.stats
 
 # Creating metadata fpr tests
 MIDDLE_TIME = 1691795333.43713
@@ -19,6 +20,10 @@ POLS = ["h"]
 CENTER_FREQ = 1284000000.0
 BANDWIDTH = 856000000.0
 N_CHANNELS = 1000
+
+# Conversion factor between standard deviation and
+# full width at half maximum (FWHM) of Gaussian beam.
+FWHM_SCALE = np.sqrt(8 * np.log(2))
 
 
 def _pointing_offsets(max_extent, num_pointings):
@@ -182,3 +187,116 @@ def test_fit_primary_beams():
                 expected_widths[ant][chunk], abs=0.0001)
             assert beams[ant][chunk].center == pytest.approx(
                 compare_beam_center[ant][chunk].center, abs=0.001)
+
+
+def _beam_params(beam):
+    """Extract beam parameters [A, x0, y0, fwhm_x, fwhm_y] as a vector."""
+    return np.r_[beam.height, beam.center, beam.width]
+
+
+def _beam_params_std(beam, error_scale):
+    """Extract stdev of beam parameters [A, x0, y0, fwhm_x, fwhm_y] as vector."""
+    return np.r_[beam.height, beam.width / FWHM_SCALE, beam.width] * error_scale
+
+
+def test_gaussian_beam_fit_accuracy():
+    r"""Reproduce Jim Condon's 2-D Gaussian fitting simulation.
+
+    This repeats a computer simulation described in [Condon1997]_, which
+    estimates the uncertainty on the fitted parameters of a 2-D elliptical
+    Gaussian fitted to samples on a regular square grid of "pixels". This
+    function goes a step further and tests the residuals for normality as
+    a unit test.
+
+    Notes
+    -----
+    The variable names try to stick to the notation of the paper for clarity.
+
+    Quoting from the [Condon1997]_ paper::
+
+      I generated an empty 1024 x 1024 pixel image and inserted Gaussian
+      pseudorandom noise with rms amplitude :math:`\mu` into each pixel of
+      area :math:`h^2`. Then 1000 elliptical Gaussians with amplitude
+      :math:`A = 20\mu`, major diameter :math:`\theta_M = 4h`, minor diameter
+      :math:`\theta_m = 10h/3`, and position angle :math:`\phi = 45^{\circ}:
+      were added to the image. The 1000 sets of parameters :math:`A`,
+      :math:`x_0`, :math:`y_0`, :math:`\theta_M`, :math:`\theta_m`, and
+      :math:`\phi` were extracted by Gaussian fitting. Figure 1 shows
+      histograms of the differences between the fitted and input parameters,
+      normalized by the theoretical rms errors, which were obtained by
+      inserting the fitted (rather than the normally unknown input) parameter
+      values into Eqs. (20) and (21). These histograms match the calculated
+      unit Gaussians (continuous curves) within the expected sampling errors.
+
+    References
+    ----------
+    .. [Condon1997] J. J. Condon, "Errors in Elliptical Gaussian Fits,"
+       PASP, vol. 109, pp. 166-172, Feb 1997.
+    """
+    # The number of Gaussians to fit
+    T = 1000
+    # The size of a pixel in data coordinates (i.e. length of each pixel side)
+    h = 0.1
+    # The rms noise amplitude on each pixel
+    mu = 0.01
+    # The pixel locations along each axis (x or y), wide enough to cover beam
+    samples_1d = h * np.arange(-30, 30)
+    # Generate square "image" on which Gaussians will be sampled
+    xy_k = np.reshape(np.meshgrid(samples_1d, samples_1d), (2, -1))
+    # Generate beam centers within a few pixels of origin
+    x0, y0 = 10 * h * (np.random.rand(2, T) - 0.5)
+    # Beam amplitude
+    A = 20 * mu
+    # Beam diameters along x and y
+    # XXX We had to double the width to avoid excessive fitting failures
+    theta_M = 8 * h
+    theta_m = 20 * h / 3
+    # Vary the beam diameter by a few percent to make it more realistic
+    fwhm_x = theta_M * (1 + 0.04 * (np.random.rand(T) - 0.5))
+    fwhm_y = theta_m * (1 + 0.04 * (np.random.rand(T) - 0.5))
+    # Beam position angle is set to phi = 0 instead due to fitter limitation
+    # Effective number of independent samples in fitted Gaussian
+    N = (np.pi / FWHM_SCALE ** 2) * fwhm_x * fwhm_y / h ** 2
+    # Overall signal-to-noise (voltage) ratio of the Gaussian fit
+    rho = np.sqrt(N) * (A / mu)
+    # Overall scale factor for parameter errors
+    error_scale = np.sqrt(2) / rho
+    # Normalized differences between fitted and true parameters / uncertainties
+    p_errors = np.full((10, T), np.nan)
+    # Iterate over Gaussians to fit
+    for t in range(T):
+        # XXX This assumes that BeamPatternFit fits a Gaussian beam
+        true_beam = pointing.BeamPatternFit((x0[t], y0[t]), (fwhm_x[t], fwhm_y[t]), A)
+        # Generate noisy beam amplitude samples on pixel grid
+        a_k = true_beam(xy_k) + mu * np.random.randn(xy_k.shape[1])
+        # Assume we have a good idea of beamwidth (needed to check beam validity)
+        beam = pointing.BeamPatternFit((0.0, 0.0), (theta_M, theta_m), max(a_k))
+        beam.fit(xy_k, a_k, mu)
+        if not beam.is_valid:
+            continue
+        # Theoretical rms errors (based on fitted parameters)
+        beam_std = _beam_params_std(beam, error_scale[t])
+        # Compare estimated / fitted to true parameters and standardise the errors
+        p_errors[:5, t] = (_beam_params(beam) - _beam_params(true_beam)) / beam_std
+        # Estimated beam parameter uncertainties from fitter
+        beam_std_estm = np.r_[beam.std_height, beam.std_center, beam.std_width]
+        # Theoretical rms errors (based on true parameters)
+        true_beam_std = _beam_params_std(true_beam, error_scale[t])
+        # XXX Estimate the uncertainty of the uncertainty (beware, thumbsuck!)
+        beam_std_std = beam_std * error_scale[t]
+        beam_std_std[0] *= 0.7
+        beam_std_std[1:] *= 0.8 * np.sqrt(FWHM_SCALE)
+        # Compare estimated / fitted to true uncertainties and standardise errors
+        p_errors[5:, t] = (beam_std_estm - true_beam_std) / beam_std_std
+    # Remove failed fits
+    p_errors = p_errors[:, np.isfinite(p_errors[0])]
+    # Check the success rate of the fits
+    assert p_errors.shape[1] >= np.floor(0.995 * T)
+    # Check 5 parameters and 5 uncertainties individually
+    for p_error in p_errors:
+        # Check that errors are standard normal (mean=0, std=1).
+        # The threshold is 1 - 0.95 ** 0.05 to ensure a 5% chance of a random
+        # assert failure when doing 20 checks (two checks each on 10 variables).
+        assert scipy.stats.kstest(p_error, scipy.stats.norm.cdf).pvalue > 0.0026
+        # Check that errors are normal (more stringent on outliers)
+        assert scipy.stats.shapiro(p_error).pvalue > 0.0026


### PR DESCRIPTION
Replace `GaussianFit` with the very similar `Gaussian2D` model in Astropy's `modeling` module. This is an existing dependency with better support and more features. It also avoids having to add `scikits.fitting` to the docker base image in order to satisfy `katsdpcal`'s dependencies due to the way `install_pinned.py` works. For the record, `scikits.fitting` started out in the `scape` package back in 2007, while Astropy models had its initial commit only in 2013, in case you wondered why we did not use Astropy models from the start. 🙂 

I added a unit test based on Jim Condon's elliptical Gaussian paper to verify that both the old and new fitters achieve the expected parameter accuracies. This is useful in itself if we ever wish to improve the fitter.