### PR TITLE
SPP1-39 Ensure wavg_t_f has the correct dimensions

### DIFF
--- a/src/katsdpcalproc/calprocs_dask.py
+++ b/src/katsdpcalproc/calprocs_dask.py
@@ -302,7 +302,7 @@ def wavg_full_f(data, flags, weights, chanav, threshold=0.8):
     # This would be simple with da.core.map_blocks, but it doesn't
     # support multiple outputs, so we need to do manual construction
     # of the dask graphs.
-    chunks = _align_chunks(data.chunks, {1: chanav})
+    chunks = _align_chunks(data.chunks, {-3: chanav})
     out_chunks = list(chunks)
     # Divide by chanav, rounding up
     # use axis -3 for freq, to support cases where time axis has been averaged away


### PR DESCRIPTION
The function `calprocs_dask.wavg_t_f` averages over all times and in frequency blocks. It calls `calprocs_dask.wavg_f` which manually aligns the dask chunks to the frequency blocks that are being averaged over.

However this manual alignment was being done on axis=1, which is the incorrect axis for the case when the time axis has been averaged away and instead the alignment should be done on axis=-3 to be general for the case where a time axis does and doesn't exist.

Misalignment between the chunk sizes and the dimensions of the final averaged array resulted in averaged arrays with the incorrect dimensions which caused problems when assembling the arrays in the report which assumes arrays of the appropriate dimensions.